### PR TITLE
chore: alpha-sort keyword_to_sentence.yml file

### DIFF
--- a/lib/keyword_to_sentence.yml
+++ b/lib/keyword_to_sentence.yml
@@ -1,11 +1,11 @@
 ---
 'APPLE':
+  - 'HEY APPLE'
+  - 'HEY APPLE'
+  - 'HEY APPLE'
+  - 'HEY APPLE'
+  - 'HEY APPLE'
   - 'HEY HEY APPLE'
-  - 'HEY APPLE'
-  - 'HEY APPLE'
-  - 'HEY APPLE'
-  - 'HEY APPLE'
-  - 'HEY APPLE'
   - 'HEY'
 'TITI':
   - 'DO U LUV ME'
@@ -45,24 +45,24 @@
   - 'FLKS'
   - 'FLX'
 'MARTIN':
-  - 'MYSTERE'
   - 'FLEX'
   - 'MATIN'
+  - 'MYSTERE'
 'ARTIN':
-  - 'YSTERE'
-  - 'LEX'
   - 'ATIN'
+  - 'LEX'
+  - 'YSTERE'
 'MRTN':
-  - 'MSTR'
   - 'FLX'
+  - 'MSTR'
   - 'MTN'
 'FETA':
-  - "D'URGENCE"
   - 'CAGOULE'
-  - 'VALISE'
+  - "D'URGENCE"
   - 'MERDE'
-  - 'RTIFLEX'
   - 'RTIFLETTE'
+  - 'RTIFLEX'
   - 'RTINE'
   - 'TZIKI'
+  - 'VALISE'
   - 'BLIER'


### PR DESCRIPTION
Using the trivial Vim command:

```
:g/^'/+,/\(^'\)\|\%$/-sort /\A*/
```