### PR TITLE
Use github actions

### DIFF
--- a/.github/config/rubocop_linter_action.yml
+++ b/.github/config/rubocop_linter_action.yml
@@ -1,0 +1,3 @@
+versions:
+  - rubocop
+  - rubocop-rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,5 +22,6 @@ jobs:
         uses: andrewmcodes/rubocop-linter-action@v3.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true  
       - name: Run tests
         run: bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,19 @@
+name: Ruby
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+    - name: Install apt dependencies
+      run: sudo apt-get install -y libsox-fmt-all sox libchromaprint-dev espeak lame
+    - name: Install gem dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,18 +9,18 @@ jobs:
       matrix:
         ruby_version: [2.6, 2.7]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby_version }}
-    - name: Install apt dependencies
-      run: sudo apt-get install -y libsox-fmt-all sox libchromaprint-dev espeak lame
-    - name: Install gem dependencies
-      run: bundle install
-    - name: Rubocop Linter Action
-      uses: andrewmcodes/rubocop-linter-action@v3.2.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Run tests
-      run: bundle exec rspec
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+      - name: Install apt dependencies
+        run: sudo apt-get install -y libsox-fmt-all sox libchromaprint-dev espeak lame
+      - name: Install gem dependencies
+        run: bundle install
+      - name: Rubocop Linter Action
+        uses: andrewmcodes/rubocop-linter-action@v3.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run tests
+        run: bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,5 +15,9 @@ jobs:
       run: sudo apt-get install -y libsox-fmt-all sox libchromaprint-dev espeak lame
     - name: Install gem dependencies
       run: bundle install
+    - name: Rubocop Linter Action
+      uses: andrewmcodes/rubocop-linter-action@v3.2.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
       run: bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,12 +5,15 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby_version: [2.6, 2.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: ${{ matrix.ruby_version }}
     - name: Install apt dependencies
       run: sudo apt-get install -y libsox-fmt-all sox libchromaprint-dev espeak lame
     - name: Install gem dependencies

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install gem dependencies
         run: bundle install
       - name: Rubocop Linter Action
-        uses: andrewmcodes/rubocop-linter-action@v3.2.0
+        uses: andrewmcodes/rubocop-linter-action@v3.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests


### PR DESCRIPTION
Note: la PR retire pas CircleCI

La PR permet d'utiliser les github actions pour lancer les tests (sur ruby 2.6 & 2.7, parce que pourquoi pas).  
J'ai aussi rajouté rubocop, mais il y a pas mal de warning (187) et il faudrait soit configurer les warnings qu'on, soit les fixer (un depend pas de moi, l'autre et clairement hors-scope).  
J'ai mis le job rubocop en `continue-on-error`, mais ca fait pas ce que je pensait: il passe aux étapes d'apres (ie les tests) mais marque quand meme le build en fail (plutot que eg "success with warnings").

Je peux aussi juste retirer les commits sur rubocop si tu penses que c'est mieux (mais j'ai appris que ruby avait des frozen-string-literal maintenant !).